### PR TITLE
Move donate message to donation block

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The `config.php` file also contains lots of options to control how the applicati
 
 | Value                   | Type    | Default   | Explanation                                 |
 |-------------------------|---------|-----------|---------------------------------------------|
-| `display_donation_text` | Boolean | `true`    | Display text to encourage donations         |
+| `display_donation_text` | Boolean | `false`    | Display text to encourage donations        |
 | `donation_address`      | String  | `not_set` | Bitcoin address to advertise for donations  |
 | `donation_amount`       | String  | `0.001`   | Donation amount - not currently implemented |
 

--- a/html/template.html
+++ b/html/template.html
@@ -82,14 +82,15 @@
       if ($config['intro_text'] != 'not_set') {
         echo '<p class="intro">'.$config['intro_text'].'</p>' . "\n";
       }
-
-      if ($config['display_donation_text'] === TRUE) {
-        echo '<p class="donation">' . "Please support this Bitcoin node by donating to <a href='http://blocktrail.com/address/" . $config['donation_address'] . "' target='_blank'>" . $config['donation_address'] . "</a></p>";
-      }
     ?>
   </div>
 
   <div class="pure-u-1 pure-u-md-1-2 pure-u-lg-1-3 image">
+    <?php 
+      if ($config['display_donation_text'] === TRUE) {
+        echo '<p class="donation">' . "Please support this Bitcoin node by donating to <a href='http://blocktrail.com/address/" . $config['donation_address'] . "' target='_blank'>" . $config['donation_address'] . "</a></p>";
+      } 
+    ?>
     <?php if (strcmp($config['donation_address'],'not_set') == 0){ echo '<img src="img/logo.png" alt="Bitcoin Logo" class="logo" />'; } else { echo generateDonationImage(); } ?>
     <?php if ((is_array($config['node_links'])) & (count($config['node_links']) > 0)) { echo '<div style="padding:10px;text-align:center"><p class="stat"><span class="label">Node Links</span></p>'; foreach ($config['node_links'] as $node_link) { ?>
         <a target="_blank" title="<?php echo $node_link['name']; ?>" href="<?php echo $node_link['link']; ?>"><?php if(isset($node_link['image'])) { ?><img src="<?php echo $node_link['image']; ?>" style="float: left;margin-left: 20px" alt="<?php echo $node_link['name']; ?>"/><?php } else { echo $node_link['name']; } ?></a>

--- a/php/config.sample.php
+++ b/php/config.sample.php
@@ -19,7 +19,7 @@ $config = array(
   'rpc_ssl_ca'                => null,
 
   // Donations
-  'display_donation_text'     => true,
+  'display_donation_text'     => false,
   'donation_address'          => 'not_set',
   'donation_amount'           => '0.001',
 


### PR DESCRIPTION
I think it makes more sense semantically for the donation message to be within the block with the QR code. That way if the `intro_block` contains a string this provides a more dedicated space and clearance for that message to be displayed across the overall width of the web app.