### PR TITLE
Ability to customise the title/main heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,20 +142,21 @@ The `config.php` file also contains lots of options to control how the applicati
 
 ### UI
 
-| Value   | Type    | Default | Explanation                                                                                                                          |
-|----------------------------|---------|-----------|-----------------------------------------------------------------------------------------------------------------|
-| `display_ip`               | Boolean | `false`   | Display the server IP address                                                                                   |
-| `display_free_disk_space`  | Boolean | `false`   | Displayfree disk space                                                                                          |
-| `display_testnet`          | Boolean | `false`   | Display testnet status                                                                                          |
-| `display_version`          | Boolean | `true`    | Display node `bitcoind` version                                                                                 |
-| `display_github_ribbon`    | Boolean | `true`    | Displays the 'Fork me on GitHub' ribbon                                                                         |
-| `display_max_height`       | Boolean | `false`   | Displays the node height as a percentage of network height                                                      |
-| `use_bitcoind_ip`          | Boolean | `true`    | Use the Bitcoin daemon to get the public IP, instead of `$_SERVER`                                              |
-| `intro_text`               | String  | `not_set` | Introductory text to display above the node statistics.                                                         |
-| `display_bitnodes_info`    | Boolean | `false`   | Displays various information via the bitnodes.earn.com API                                                      |
-| `display_chart`            | Boolean | `false`   | Displays a chart showing the stats collected by the stats.php script                                            |
-| `display_peer_chart`       | Boolean | `false`   | Displays a chart showing the mix of node versions connected to your node                                        |
-| `node_links`               | Array   | `array()` | Displays links to various other profiles for your node. Takes the form of a multidimensional array, see example |
+| Value                      | Type    | Default               | Explanation                                                                                        |
+|----------------------------|---------|-----------------------|--------------------------------------------------------------------------------------------------- |
+| `display_ip`               | Boolean | `false`               | Display the server IP address                                                                      |
+| `display_free_disk_space`  | Boolean | `false`               | Displayfree disk space                                                                             |
+| `display_testnet`          | Boolean | `false`               | Display testnet status                                                                             |
+| `display_version`          | Boolean | `true`                | Display node `bitcoind` version                                                                    |
+| `display_github_ribbon`    | Boolean | `true`                | Displays the 'Fork me on GitHub' ribbon                                                            |
+| `display_max_height`       | Boolean | `false`               | Displays the node height as a percentage of network height                                         |
+| `use_bitcoind_ip`          | Boolean | `true`                | Use the Bitcoin daemon to get the public IP, instead of `$_SERVER`                                 |
+| `intro_text`               | String  | `not_set`             | Introductory text to display above the node statistics.                                            |
+| `title_text`               | String  | `Bitcoin Node Status` | Value to display for the web browser title and main heading                                        |
+| `display_bitnodes_info`    | Boolean | `false`               | Displays various information via the bitnodes.21.co API                                            |
+| `display_chart`            | Boolean | `false`               | Displays a chart showing the stats collected by the stats.php script                               |
+| `display_peer_chart`       | Boolean | `false`               | Displays a chart showing the mix of node versions connected to your node                           |
+| `node_links`               | Array   | `array()`             | Displays links to various other profiles for your node, see "Node Profile Icons"example            |
 
 ### Stats
 

--- a/html/template.html
+++ b/html/template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Bitcoin Node Status</title>
+  <title><?php echo isset($config['title_text']) ? $config['title_text'] : $default_app_title; ?></title>
   <link rel="icon" type="image/png" href="img/favicon.png" />
   <link rel="stylesheet" href="css/pure-min.css">
   <link rel="stylesheet" href="css/flags.css">
@@ -73,7 +73,7 @@
 <div id="container" class="pure-g">
 
   <div class="pure-u-1 pure-u-md-1-1">
-    <h1>Bitcoin Node Status</h1>
+    <h1><?php echo isset($config['title_text']) ? $config['title_text'] : $default_app_title; ?></h1>
     <?php
       if (isset($cache_message)) {
         echo '<p class="cache small">' . $cache_message . '</p>';

--- a/php/config.sample.php
+++ b/php/config.sample.php
@@ -52,6 +52,7 @@ $config = array(
   'display_max_height'        => true,
   'use_bitcoind_ip'           => true,
   'intro_text'                => 'not_set',
+  'title_text'                => 'Bitcoin Node Status',
   'display_bitnodes_info'     => false,
   'display_chart'             => false,
   'display_peer_chart'        => false,

--- a/php/functions.php
+++ b/php/functions.php
@@ -10,6 +10,7 @@
  */
 
 $curl_requests = 0;
+$default_app_title = 'Bitcoin Node Status';
 
 /**
  * Connects to Bitcoin daemon and retrieves information, then writes to cache


### PR DESCRIPTION
Currently the `<title>` and `<h1>` value is hard coded, this allows the user to change it to whatever they desire. I've used a small function with `isset()` to essentially check if `title_text` is set and if it is, use it as value for these elements. A default title value is set in functions.php for older configurations which will not have this config value to break a blank value.