### PR TITLE
Fix IPv6 peer output in $peer_addr_array and add doc for how to ignore peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ below. Icon images for Bitnodes.21.co and Blockchain.info are included in the `i
     ),
 ```
 
+## Ignoring Certain Peers
+
+To ignore any specific peer from appearing in the connections table. Write the IPv4 or IPv6 address of the peer in the array like the example below.
+
+```
+    'peers_to_ignore' => array (
+        '192.168.0.10',
+        '[2a01:4f8:121:14f7::2]'
+  ),
+```
+
 ## Peer Count Nodes
 
 The node count script automatically counts Core, Classic, Unlimited and BitcoinJ clients. To add more node types to the chart, simply add an entry into the `peercount_extra_nodes` array in `config.php`.

--- a/php/functions.php
+++ b/php/functions.php
@@ -76,7 +76,6 @@ function getData($from_cache = false)
 
     // Store network info in data array
     $data['net_info'] = $bitcoin->getnetworkinfo();
-    var_dump($data['net_info']);
 
     if ($config['display_ip'] === true) {
         // Use bitcoind IP
@@ -191,7 +190,6 @@ function parsePeers($peers, $curl_handle)
     foreach ($peers as $peer) {
 
         // Extract IP address for later
-        //$peer_addr_array = explode(':', $peer['addr']);
         $peer_addr_array = preg_split('/\:(?=[^:]*$)/', $peer['addr']);
         $peer_ip = $peer_addr_array[0];
 

--- a/php/functions.php
+++ b/php/functions.php
@@ -76,6 +76,7 @@ function getData($from_cache = false)
 
     // Store network info in data array
     $data['net_info'] = $bitcoin->getnetworkinfo();
+    var_dump($data['net_info']);
 
     if ($config['display_ip'] === true) {
         // Use bitcoind IP
@@ -190,7 +191,8 @@ function parsePeers($peers, $curl_handle)
     foreach ($peers as $peer) {
 
         // Extract IP address for later
-        $peer_addr_array = explode(':', $peer['addr']);
+        //$peer_addr_array = explode(':', $peer['addr']);
+        $peer_addr_array = preg_split('/\:(?=[^:]*$)/', $peer['addr']);
         $peer_ip = $peer_addr_array[0];
 
         // Continue if peer is 'dark'


### PR DESCRIPTION
This should fix #41. Essentially the match of the colon for splitting apart ip:port uses regex to only match the last occurrence of the `:` character to work for IPv6 peer addresses.

Also add a bit of documentation for how to ignore peers, with this you'll also be able to hide IPv6 peers because the array output will now be fixed and match properly.