### PR TITLE
Fix logic error on display_bitcoind_uptime

### DIFF
--- a/php/functions.php
+++ b/php/functions.php
@@ -104,7 +104,7 @@ function getData($from_cache = false)
     }
 
     // Bitcoin Daemon uptime
-    if (($config['display_bitcoind_uptime'] === true) || (strcmp(PHP_OS, "Linux") == 0)) {
+    if (($config['display_bitcoind_uptime'] === true) && (strcmp(PHP_OS, "Linux") == 0)) {
         $data['bitcoind_uptime'] = getProcessUptime($config['bitcoind_process_name']);
     }
 


### PR DESCRIPTION
This looks like a bug to me. Both conditions should be true here, otherwise you can have a situation where `display_bitcoind_uptime` is to set to false in the config, but if deployed on a Linux stack, PHP_OS condition would then be true and then `bitcoind_uptime` is set. Not desirable, if you want this option disabled because the bitcoind process is not running on the same box.