### PR TITLE
Updated address view URL as Blocktrail has ceased operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - hhvm
   - nightly
 before_script: composer install
 script: ./run_tests.sh

--- a/html/template.html
+++ b/html/template.html
@@ -88,7 +88,7 @@
   <div class="pure-u-1 pure-u-md-1-2 pure-u-lg-1-3 image">
     <?php
       if (($config['display_donation_text'] === TRUE) && ($config['donation_address'] !== 'not_set')) {
-        echo '<p class="donation">' . "Please support this Bitcoin node by donating to <a href='http://blocktrail.com/address/" . $config['donation_address'] . "' target='_blank'>" . $config['donation_address'] . "</a></p>";
+        echo '<p class="donation">' . "Please support this Bitcoin node by donating to <a href='https://www.blockchain.com/btc/address/" . $config['donation_address'] . "' target='_blank'>" . $config['donation_address'] . "</a></p>";
       }
     ?>
     <?php if (strcmp($config['donation_address'],'not_set') == 0){ echo '<img src="img/logo.png" alt="Bitcoin Logo" class="logo" />'; } else { echo generateDonationImage(); } ?>
@@ -188,7 +188,7 @@
     <hr />
     <p>
        <a href="https://github.com/craigwatson/bitcoind-status">Bitcoin Daemon Status Page</a> by <a href="https://cwatson.org">Craig Watson</a>, distributed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License v2.0</a><br />
-       Please send donations to: <a href="https://www.blocktrail.com/BTC/address/15sLQBY3TnCRX5rYLqt8gxPqmnxU4JrKBn" target="_blank">15sLQBY3TnCRX5rYLqt8gxPqmnxU4JrKBn</a><br />
+       Please send donations to: <a href="https://www.blockchain.com/btc/address/15sLQBY3TnCRX5rYLqt8gxPqmnxU4JrKBn" target="_blank">15sLQBY3TnCRX5rYLqt8gxPqmnxU4JrKBn</a><br />
        IP Geolocation by <a href="http://www.geoplugin.com" target="_new">geoPlugin</a>, using GeoLite2 data from <a href="https://www.maxmind.com" target="_new">MaxMind</a><br />
        Page generated in <?php echo round((microtime(TRUE)-$_SERVER['REQUEST_TIME_FLOAT']), 4); ?> seconds, using <?php echo $curl_requests; ?> remote request(s)<br />
     </p>


### PR DESCRIPTION
The existing links to Blocktrail now display a page informing users that Blocktrail has ceased operations. This PR switches to using blockchain.com instead.