### PR TITLE
Forcing 'chartdata.php' to return the correct 'Content-Type' header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - hhvm
   - nightly
 before_script: composer install
 script: ./run_tests.sh

--- a/chartdata.php
+++ b/chartdata.php
@@ -16,6 +16,8 @@ if (!isset($_GET['stat'])) {
 
 require_once './php/config.php';
 
+header('Content-Type: application/javascript');
+
 switch($_GET['stat']) {
 case 'connection':
     $data_file  = $config['stats_file'];


### PR DESCRIPTION
When strict MIME type checking is enabled, the calls to `/chartdata.php` fail as a `Content-Type` of `text/html` is returned. This PR forces a `Content-Type` of `application/javascript`.